### PR TITLE
Convert magic number to enum

### DIFF
--- a/homeassistant/components/ephember/climate.py
+++ b/homeassistant/components/ephember/climate.py
@@ -22,9 +22,9 @@ class EPHDeviceType(IntEnum):
 
 from pyephember.pyephember import (
     EphEmber,
+    boiler_state,
     ZoneMode,
     zone_current_temperature,
-    zone_is_active,
     zone_is_boost_active,
     zone_mode,
     zone_name,

--- a/homeassistant/components/ephember/climate.py
+++ b/homeassistant/components/ephember/climate.py
@@ -4,9 +4,17 @@ from __future__ import annotations
 from datetime import timedelta
 import logging
 from typing import Any
-from enum import Enum
+from enum import IntEnum
 
-class EPHDeviceType(Enum):
+class EPHBoilerStates(IntEnum):
+    """
+    Boiler states for a zone given by the api
+    """
+    FIXME = 0
+    OFF = 1
+    ON = 2
+
+class EPHDeviceType(IntEnum):
     """
     DeviceType numbers returned by API
     """
@@ -121,7 +129,7 @@ class EphEmberThermostat(ClimateEntity):
     @property
     def hvac_action(self) -> HVACAction:
         """Return current HVAC action."""
-        if zone_is_active(self._zone):
+        if boiler_state(self._zone) == EPHBoilerStates.ON:
             return HVACAction.HEATING
 
         return HVACAction.IDLE

--- a/homeassistant/components/ephember/climate.py
+++ b/homeassistant/components/ephember/climate.py
@@ -4,6 +4,13 @@ from __future__ import annotations
 from datetime import timedelta
 import logging
 from typing import Any
+from enum import Enum
+
+class EPHDeviceType(Enum):
+    """
+    DeviceType numbers returned by API
+    """
+    IMMERSION = 4     # device type for immersions returned by EPH
 
 from pyephember.pyephember import (
     EphEmber,
@@ -89,8 +96,7 @@ class EphEmberThermostat(ClimateEntity):
         self._ember = ember
         self._zone_name = zone_name(zone)
         self._zone = zone
-        self._hot_water = zone['deviceType'] == 4
-        """4 is a specific device type for immersions returned by EPH. Hot Water temp cannot be changed"""
+        self._hot_water = zone['deviceType'] == EPHDeviceType.IMMERSION # Hot Water temp cannot be changed
         
         self._attr_name = self._zone_name
 


### PR DESCRIPTION
Feedback in https://github.com/home-assistant/core/pull/94533 suggested migrating the deviceType magic number to an enum to make it more clear. This should do so, hopefully unblocking the ephember update in homeassistant.